### PR TITLE
Enhance Presenter Proxy

### DIFF
--- a/Sources/SheeKit/SheetPresenterController.swift
+++ b/Sources/SheeKit/SheetPresenterController.swift
@@ -65,7 +65,6 @@ final class SheetPresenterController: UIViewController {
             presenterProxy = parent
             willMove(toParent: nil)
             removeFromParent()
-            assert(parent!.presentedViewController == nil)
         } else if parent != nil {
             presenterProxy = self
         } else {

--- a/Sources/SheeKit/SheetPresenterController.swift
+++ b/Sources/SheeKit/SheetPresenterController.swift
@@ -65,6 +65,7 @@ final class SheetPresenterController: UIViewController {
             presenterProxy = parent
             willMove(toParent: nil)
             removeFromParent()
+            assert(parent!.presentedViewController == nil)
         } else if parent != nil {
             presenterProxy = self
         } else {
@@ -164,7 +165,15 @@ struct SheetPresenterControllerRepresentable<Item>: UIViewControllerRepresentabl
                     let sheetHost = sheetHostProvider(coordinator, presenter, item, dismissAction)
                     sheetHost.onDismiss = onDismiss
                     sheetHost.presentationController?.delegate = coordinator
-                    presenter.presenterProxy?.present(sheetHost, animated: true)
+                    guard let presenterProxy = presenter.presenterProxy else {
+                        // fatalError("no presenter")
+                        return
+                    }
+                    var controllerToPresentFrom: UIViewController = presenterProxy
+                    while let presented = controllerToPresentFrom.presentedViewController {
+                        controllerToPresentFrom = presented
+                    }
+                    controllerToPresentFrom.present(sheetHost, animated: true)
                 }
                 if let previousSheetHost = coordinator.sheetHost,
                    previousSheetHost.itemId == nil,


### PR DESCRIPTION
Before this change, a "SheetHost" view controller might not be presented
if the presenter already presented another view controller. This might
have happened when a sheet will be presented due to a state change
originating from an app state, rather from a user intent, and when there
is already a presented view or a presented alert.

This change walks the presented view controller list until it finds a
view controller which has no presented view controller and uses this as
the presenter. As a result, a sheet now presents on top of any other
presented view, even on top of alerts.